### PR TITLE
Fixing puppet-agent-oauth check to also work with debian based systems

### DIFF
--- a/hooks/pre/31-puppet_agent_oauth.rb
+++ b/hooks/pre/31-puppet_agent_oauth.rb
@@ -6,4 +6,11 @@ unless app_value(:noop)
       logger.error("Failed to reinstall puppet-agent-oauth. Please check that the package is available from a repository.") unless success
     end
   end
+  if File.exist?('/opt/puppetlabs/puppet/bin/ruby') && execute("dpkg-query --show --showformat='${db:Status-Status}' puppet-agent-oauth | grep -q '^installed'", false, false)
+    unless execute("/opt/puppetlabs/puppet/bin/ruby -e \"require 'oauth'\"", false, false)
+      success = execute("apt-get --reinstall install puppet-agent-oauth", false, true)
+
+      logger.error("Failed to reinstall puppet-agent-oauth. Please check that the package is available from a repository.") unless success
+    end
+  end
 end


### PR DESCRIPTION
This fixes the check for a correctly working puppet-agent-oauth package also for debian based systems.

Maybe this can be made smarter code-wise, but it should do the needful.

(There is no redmine ticket related to this so far)